### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This repository contains a Model Context Protocol (MCP) server with tools that can access the OpenTelemetry traces and
 metrics you've sent to Logfire.
 
+<a href="https://glama.ai/mcp/servers/@pydantic/logfire-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pydantic/logfire-mcp/badge" alt="Logfire Server MCP server" />
+</a>
+
 This MCP server enables LLMs to retrieve your application's telemetry data, analyze distributed
 traces, and make use of the results of arbitrary SQL queries executed using the Logfire APIs.
 


### PR DESCRIPTION
This PR adds a badge for the [Logfire MCP Server](https://glama.ai/mcp/servers/@pydantic/logfire-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@pydantic/logfire-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pydantic/logfire-mcp/badge" alt="Logfire Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.