### PR TITLE
Fix README default URL to match code implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Add to your Cline settings in `cline_mcp_settings.json`:
 
 ### Customization - Base URL
 
-By default, the server connects to the Logfire API at `https://logfire-api.pydantic.dev`. You can override this by:
+By default, the server connects to the Logfire API at `https://api-us.pydantic.dev`. You can override this by:
 
 1. Using the `--base-url` argument:
 ```bash


### PR DESCRIPTION
Related to https://github.com/pydantic/logfire-mcp/issues/12.

Showing the default URL with -us hints at the existing of the -eu URL.