### PR TITLE
connect on startup

### DIFF
--- a/logfire_mcp/main.py
+++ b/logfire_mcp/main.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any, Literal, TypedDict, cast
 
 from logfire.experimental.query_client import AsyncLogfireQueryClient
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp.server import logger as mcp_logger
 from mcp.server.session import ServerSession
 from pydantic import Field, WithJsonSchema
 
@@ -95,9 +96,10 @@ async def logfire_link(ctx: Context[ServerSession, MCPState], trace_id: str) -> 
 def app_factory(logfire_read_token: str, logfire_base_url: str | None = None) -> FastMCP:
     @asynccontextmanager
     async def lifespan(server: FastMCP) -> AsyncIterator[MCPState]:
-        # print to stderr so we this message doesn't get read by the MCP client
         headers = {'User-Agent': f'logfire-mcp/{__version__}'}
         async with AsyncLogfireQueryClient(logfire_read_token, headers=headers, base_url=logfire_base_url) as client:
+            logfire_info = await client.info()
+            mcp_logger.info('Starting Logfire MCP server, connection: %s', logfire_info)
             yield MCPState(logfire_client=client)
 
     mcp = FastMCP('Logfire', lifespan=lifespan)


### PR DESCRIPTION
With this the MCP server will connect when creating the server and thus fail if the read token is not valid.