### PR TITLE
Validate read token on MCP server startup

### DIFF
--- a/tests/cassettes/test_invalid_token/test_invalid_token.yaml
+++ b/tests/cassettes/test_invalid_token/test_invalid_token.yaml
@@ -1,0 +1,26 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - logfire-us.pydantic.dev
+      user-agent:
+      - logfire-mcp/0.3.2
+    method: GET
+    uri: https://logfire-us.pydantic.dev/v1/read-token-info
+  response:
+    body:
+      string: '{"detail":"Invalid read token"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/tests/cassettes/test_logfire_link/test_logfire_link.yaml
+++ b/tests/cassettes/test_logfire_link/test_logfire_link.yaml
@@ -11,7 +11,37 @@ interactions:
       host:
       - logfire-us.pydantic.dev
       user-agent:
-      - logfire-mcp/0.3.2.dev7+6fc4700
+      - logfire-mcp/0.3.2
+    method: GET
+    uri: https://logfire-us.pydantic.dev/v1/read-token-info
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/12NQQ7CIBBF78LaSYBSKF7GDDA0aIWmxRg13t1WuzBdTeb/vP9erJYL5VMK7MiM
+        NI3TFEByoUAJ4aEzpIEikgncK4rEDqxMPeb0xJrKBgoRsO3QQRO6CAqlB6t0C8EuR3GH5O0enG9u
+        9lMav884YF528prXJVw141TO5OvPELS23ooA3MoGFLkItnUI2EnlnZVSGr43ZLzSgg6lj2n6X9yK
+        Hivd8cHeH0L28pQFAQAA
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - logfire-us.pydantic.dev
+      user-agent:
+      - logfire-mcp/0.3.2
     method: GET
     uri: https://logfire-us.pydantic.dev/v1/read-token-info
   response:

--- a/tests/cassettes/test_readme/test_generate_readme.yaml
+++ b/tests/cassettes/test_readme/test_generate_readme.yaml
@@ -1,0 +1,32 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - logfire-us.pydantic.dev
+      user-agent:
+      - logfire-mcp/0.3.2
+    method: GET
+    uri: https://logfire-us.pydantic.dev/v1/read-token-info
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/12NQQ7CIBBF78LaSYBSKF7GDDA0aIWmxRg13t1WuzBdTeb/vP9erJYL5VMK7MiM
+        NI3TFEByoUAJ4aEzpIEikgncK4rEDqxMPeb0xJrKBgoRsO3QQRO6CAqlB6t0C8EuR3GH5O0enG9u
+        9lMav884YF528prXJVw141TO5OvPELS23ooA3MoGFLkItnUI2EnlnZVSGr43ZLzSgg6lj2n6X9yK
+        Hivd8cHeH0L28pQFAQAA
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_schema_reference/test_schema_reference.yaml
+++ b/tests/cassettes/test_schema_reference/test_schema_reference.yaml
@@ -11,7 +11,37 @@ interactions:
       host:
       - logfire-us.pydantic.dev
       user-agent:
-      - logfire-mcp/0.3.2.dev4+ae94fe7
+      - logfire-mcp/0.3.2
+    method: GET
+    uri: https://logfire-us.pydantic.dev/v1/read-token-info
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/12NQQ7CIBBF78LaSYBSKF7GDDA0aIWmxRg13t1WuzBdTeb/vP9erJYL5VMK7MiM
+        NI3TFEByoUAJ4aEzpIEikgncK4rEDqxMPeb0xJrKBgoRsO3QQRO6CAqlB6t0C8EuR3GH5O0enG9u
+        9lMav884YF528prXJVw141TO5OvPELS23ooA3MoGFLkItnUI2EnlnZVSGr43ZLzSgg6lj2n6X9yK
+        Hivd8cHeH0L28pQFAQAA
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - logfire-us.pydantic.dev
+      user-agent:
+      - logfire-mcp/0.3.2
     method: GET
     uri: https://logfire-us.pydantic.dev/v1/schemas
   response:

--- a/tests/test_invalid_token.py
+++ b/tests/test_invalid_token.py
@@ -1,0 +1,26 @@
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from logfire_mcp.main import InvalidReadTokenError, app_factory
+
+pytestmark = [pytest.mark.vcr, pytest.mark.anyio]
+
+
+@pytest.fixture
+def app_with_invalid_token() -> FastMCP:
+    return app_factory('invalid-token')
+
+
+async def test_invalid_token(app_with_invalid_token: FastMCP) -> None:
+    mcp_server = app_with_invalid_token._mcp_server  # type: ignore
+    with pytest.raises(ExceptionGroup) as exc_info:
+        async with create_connected_server_and_client_session(mcp_server, raise_exceptions=True):
+            pass
+
+    # The exception is wrapped in an ExceptionGroup
+    exception_group = exc_info.value
+    assert len(exception_group.exceptions) == 1
+    inner_exception = exception_group.exceptions[0]
+    assert isinstance(inner_exception, InvalidReadTokenError)
+    assert 'Invalid Logfire read token' in str(inner_exception)


### PR DESCRIPTION
The MCP server now validates the read token during startup by calling /v1/read-token-info. If the token is invalid (401 response), the server raises an InvalidReadTokenError with a helpful message instead of silently starting and only failing when tools are called.

This provides immediate feedback to users when their token is misconfigured, rather than the server appearing to connect successfully.

https://claude.ai/code/session_01WGp62UfX8DLL6tVGVqKR79