### PR TITLE
Fix tool name

### DIFF
--- a/logfire_mcp/__main__.py
+++ b/logfire_mcp/__main__.py
@@ -75,17 +75,15 @@ async def test(logfire_read_token: str, logfire_base_url: str | None, source: st
             for resource in list_resources.resources:
                 print(f'  - {resource.name}')
 
-            for tool in 'sql_reference', 'get_logfire_records_schema':
-                print(f'\ncalling `{tool}`:')
-                output = await session.call_tool(tool)
-                # debug(output)
-                content = output.content[0]
-                assert isinstance(content, TextContent), f'Expected TextContent, got {type(content)}'
-                if len(content.text) < 200:
-                    print(f'> {content.text.strip()}')
-                else:
-                    first_line = content.text.strip().split('\n', 1)[0]
-                    print(f'> {first_line}... ({len(content.text) - len(first_line)} more characters)\n')
+            print('\ncalling `schema_reference`:')
+            output = await session.call_tool('schema_reference')
+            content = output.content[0]
+            assert isinstance(content, TextContent), f'Expected TextContent, got {type(content)}'
+            if len(content.text) < 200:
+                print(f'> {content.text.strip()}')
+            else:
+                first_line = content.text.strip().split('\n', 1)[0]
+                print(f'> {first_line}... ({len(content.text) - len(first_line)} more characters)\n')
 
 
 def get_read_token(args: argparse.Namespace) -> tuple[str | None, str]:

--- a/logfire_mcp/main.py
+++ b/logfire_mcp/main.py
@@ -66,7 +66,7 @@ async def arbitrary_query(
 ) -> list[Any]:
     """Run an arbitrary query on the Pydantic Logfire database.
 
-    The SQL reference is available via the `sql_reference` tool.
+    The SQL reference is available via the `schema_reference` tool.
     """
     logfire_client = ctx.request_context.lifespan_context.logfire_client
     min_timestamp = datetime.now(UTC) - timedelta(minutes=age)


### PR DESCRIPTION
It seems we don't have `get_logfire_records_schema` tool. Also `sql_reference` was renamed to `schema_reference`